### PR TITLE
Added clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+---
+Checks: 'clang-diagnostic-*,clang-analyzer-*,cppcoreguidelines-*'
+WarningsAsErrors: "*"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,14 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+find_program(CMAKE_CXX_CLANG_TIDY_EXECUTABLE NAMES clang-tidy)
+if (NOT CMAKE_CXX_CLANG_TIDY_EXECUTABLE)
+  message("clang-tidy not found")
+else()
+  message("clang-tidy found")
+  set(CMAKE_CXX_CLANG_TIDY "clang-tidy")
+endif()
+
 enable_testing()
 
 add_subdirectory(src)

--- a/tests/BigIntTest.cpp
+++ b/tests/BigIntTest.cpp
@@ -1,6 +1,8 @@
 #include "gtest/gtest.h"
 #include "BigInt/BigInt.hpp"
 
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables, cppcoreguidelines-owning-memory)
+
 TEST(BigIntTest, Constructors) {
   ACA::BigInt a;          // Default constructor
   ACA::BigInt b("1234");  // String constructor
@@ -74,6 +76,8 @@ TEST(BigIntTest, SubtractionOperator) {
 
   EXPECT_EQ(c - d, ACA::BigInt("999999999999999999"));
 }
+
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables, cppcoreguidelines-owning-memory)
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
Added clang-tidy check.

clang-tidy is a static code analysis tool which will detect code flaws. For now checks are the basic ones `clang-diagnostic-*,clang-analyzer-*,cppcoreguidelines-*`

Warnings are treated as errors.

Clang-tidy reports some false positives on google test's macros. `// NOLINT...` comments are for suppressing this false positives. 